### PR TITLE
Simplify code in Liquipedia family

### DIFF
--- a/pywikibot/liquipedia_family.py
+++ b/pywikibot/liquipedia_family.py
@@ -2,7 +2,6 @@
 
 
 from pywikibot import family
-import json
 import requests
 
 
@@ -11,7 +10,7 @@ class Family(family.Family):
     @classmethod
     def __post_init__(self):
         response = requests.get('https://liquipedia.net/api.php?action=listwikis', headers={'accept-encoding': 'gzip'})
-        wikis = json.loads(response.content)
+        wikis = response.json()
         for game in wikis['allwikis'].keys():
             self.langs[game] = 'liquipedia.net'
 


### PR DESCRIPTION
This PR replaces `json.loads` in Liquipedia family script with [`Response.json`](https://requests.readthedocs.io/en/latest/api/#requests.Response.json) which calls `json.loads` internally.